### PR TITLE
`quack_like` also delegates `new_record?`

### DIFF
--- a/lib/trenchcoat.rb
+++ b/lib/trenchcoat.rb
@@ -27,7 +27,7 @@ module Trenchcoat
       end
 
       def quack_like(model_instance_attr:)
-        delegate :model_name, :persisted?, :id, to: model_instance_attr
+        delegate :model_name, :persisted?, :new_record?, :id, to: model_instance_attr
       end
     end
   end

--- a/test/test_trenchcoat.rb
+++ b/test/test_trenchcoat.rb
@@ -160,6 +160,7 @@ class TestTrenchcoat
 
       assert_equal Post.model_name, form.model_name
       assert_equal false, form.persisted?
+      assert_equal true, form.new_record?
       assert_nil form.id
     end
 
@@ -168,6 +169,7 @@ class TestTrenchcoat
 
       assert_equal Post.model_name, form.model_name
       assert_equal false, form.persisted?
+      assert_equal true, form.new_record?
       assert_nil form.id
     end
 
@@ -177,6 +179,7 @@ class TestTrenchcoat
 
       assert_equal Post.model_name, form.model_name
       assert_equal true, form.persisted?
+      assert_equal false, form.new_record?
       assert_equal post.id, form.id
     end
   end


### PR DESCRIPTION
* `new_record?` is the counterpart to `persisted?`, so it should be delegated as well for ease-of-use

This closes #2 